### PR TITLE
Fix Github Actions deprecation notices

### DIFF
--- a/.github/workflows/cleanup-artifact-registry.yml
+++ b/.github/workflows/cleanup-artifact-registry.yml
@@ -29,7 +29,7 @@ jobs:
           workload_identity_provider: projects/000000000000/locations/global/workloadIdentityPools/devops/providers/github
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0.6.0
+        uses: google-github-actions/setup-gcloud@v1.0.0
 
       - name: Get old images
         id: get-old-images

--- a/.github/workflows/cleanup-artifact-registry.yml
+++ b/.github/workflows/cleanup-artifact-registry.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3.1.0
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0.8.0
+        uses: google-github-actions/auth@v1.0.0
         with:
           service_account: github-actions-runner@rails-google-cloud-quickstart.iam.gserviceaccount.com
           workload_identity_provider: projects/000000000000/locations/global/workloadIdentityPools/devops/providers/github

--- a/.github/workflows/cleanup-artifact-registry.yml
+++ b/.github/workflows/cleanup-artifact-registry.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.1.0
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0.8.0

--- a/.github/workflows/deploy-to-cloud-run.yml
+++ b/.github/workflows/deploy-to-cloud-run.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Set deploy timestamp
         id: set-deploy-timestamp
-        run: echo "::set-output name=timestamp::$(date +%s)"
+        run: echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Deploy to Cloud Run
         id: deploy

--- a/.github/workflows/deploy-to-cloud-run.yml
+++ b/.github/workflows/deploy-to-cloud-run.yml
@@ -52,7 +52,7 @@ jobs:
       - name: URLEncode Cloud SQL Instance string
         id: url-encode-cloud-sql-instance
         run: |-
-          ruby -e 'require "erb"; puts "::set-output name=encoded-value::#{ERB::Util.url_encode("${{ inputs.cloud-sql-instance }}")}"'
+          ruby -e 'require "erb"; puts "encoded-value=#{ERB::Util.url_encode("${{ inputs.cloud-sql-instance }}")}"' >> $GITHUB_OUTPUT
 
       - name: Register Deploy Start on Github
         uses: bobheadxi/deployments@v1.3.0

--- a/.github/workflows/deploy-to-cloud-run.yml
+++ b/.github/workflows/deploy-to-cloud-run.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Deploy to Cloud Run
         id: deploy
-        uses: google-github-actions/deploy-cloudrun@v0.9.0
+        uses: google-github-actions/deploy-cloudrun@v0.10.3
         with:
           region: us-central1
           service: rails-google-cloud-quickstart-${{ inputs.deploy-name }}

--- a/.github/workflows/deploy-to-cloud-run.yml
+++ b/.github/workflows/deploy-to-cloud-run.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v3.1.0
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0.8.0
+        uses: google-github-actions/auth@v1.0.0
         with:
           service_account: github-actions-runner@rails-google-cloud-quickstart.iam.gserviceaccount.com
           workload_identity_provider: projects/000000000000/locations/global/workloadIdentityPools/devops/providers/github

--- a/.github/workflows/deploy-to-cloud-run.yml
+++ b/.github/workflows/deploy-to-cloud-run.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       # actions/checkout MUST come before auth
       - name: Checkout the code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.1.0
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0.8.0

--- a/.github/workflows/deploy-to-cloud-run.yml
+++ b/.github/workflows/deploy-to-cloud-run.yml
@@ -47,7 +47,7 @@ jobs:
           workload_identity_provider: projects/000000000000/locations/global/workloadIdentityPools/devops/providers/github
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0.6.0
+        uses: google-github-actions/setup-gcloud@v1.0.0
 
       - name: URLEncode Cloud SQL Instance string
         id: url-encode-cloud-sql-instance

--- a/.github/workflows/deploy-to-cloud-run.yml
+++ b/.github/workflows/deploy-to-cloud-run.yml
@@ -28,6 +28,14 @@ on:
         required: false
         type: number
         default: 0
+      cloud-run-service-cpu-count:
+        required: false
+        type: number
+        default: 1
+      cloud-run-service-memory:
+        required: false
+        type: string
+        default: 512Mi
 
 jobs:
   service-deploy:
@@ -83,6 +91,8 @@ jobs:
             DATABASE_URL=postgres://%2Fcloudsql%2F${{ steps.url-encode-cloud-sql-instance.outputs.encoded-value }}/${{ env.DATABASE_NAME }}
             GOOGLE_CLOUD_PROJECT=rails-google-cloud-quickstart
           flags: |-
+            --cpu ${{ inputs.cloud-run-service-cpu-count }}
+            --memory ${{ inputs.cloud-run-service-memory }}
             --allow-unauthenticated
             --add-cloudsql-instances ${{ inputs.cloud-sql-instance }}
             --min-instances=${{ inputs.cloud-run-minimum-instances }}

--- a/.github/workflows/review-env-cleanup.yml
+++ b/.github/workflows/review-env-cleanup.yml
@@ -33,7 +33,7 @@ jobs:
           workload_identity_provider: projects/000000000000/locations/global/workloadIdentityPools/devops/providers/github
 
       - name: Set up gcloud Cloud SDK environment
-        uses: google-github-actions/setup-gcloud@v0.6.0
+        uses: google-github-actions/setup-gcloud@v1.0.0
 
       - name: Remove the deployed service from Cloud Run
         run: |-

--- a/.github/workflows/review-env-cleanup.yml
+++ b/.github/workflows/review-env-cleanup.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # actions/checkout MUST come before auth
       - name: Checkout the code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.1.0
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0.8.0

--- a/.github/workflows/review-env-cleanup.yml
+++ b/.github/workflows/review-env-cleanup.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3.1.0
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0.8.0
+        uses: google-github-actions/auth@v1.0.0
         with:
           service_account: github-actions-runner@rails-google-cloud-quickstart.iam.gserviceaccount.com
           workload_identity_provider: projects/000000000000/locations/global/workloadIdentityPools/devops/providers/github

--- a/.github/workflows/review-env-setup.yml
+++ b/.github/workflows/review-env-setup.yml
@@ -34,7 +34,7 @@ jobs:
           workload_identity_provider: projects/000000000000/locations/global/workloadIdentityPools/devops/providers/github
 
       - name: Set up gcloud Cloud SDK environment
-        uses: google-github-actions/setup-gcloud@v0.6.0
+        uses: google-github-actions/setup-gcloud@v1.0.0
 
       - name: Ensure a review database exists
         run: |-

--- a/.github/workflows/review-env-setup.yml
+++ b/.github/workflows/review-env-setup.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       # actions/checkout MUST come before auth
       - name: Checkout the code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.1.0
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0.8.0

--- a/.github/workflows/review-env-setup.yml
+++ b/.github/workflows/review-env-setup.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3.1.0
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0.8.0
+        uses: google-github-actions/auth@v1.0.0
         with:
           service_account: github-actions-runner@rails-google-cloud-quickstart.iam.gserviceaccount.com
           workload_identity_provider: projects/000000000000/locations/global/workloadIdentityPools/devops/providers/github

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -33,7 +33,7 @@ jobs:
         # on our systems
         name: Generate UUID for build
         id: uuidgen
-        run: echo "::set-output name=uuid::$(uuidgen)"
+        run: echo "uuid=$(uuidgen)" >> $GITHUB_OUTPUT
 
       - name: Set additional variables
         id: variables

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Set build timestamp
         id: set-build-timestamp
-        run: echo "::set-output name=timestamp::$(date +%s)"
+        run: echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.1.0
 
       - # We'll generate a unique id that we'll use to identify the build run
         # on our systems

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -97,7 +97,7 @@ jobs:
             tmp/capybara/screenshots
 
       # - name: Authenticate to Google Cloud
-      #   uses: google-github-actions/auth@v0.8.0
+      #   uses: google-github-actions/auth@v1.0.0
       #   with:
       #     service_account: github-actions-runner@rails-google-cloud-quickstart.iam.gserviceaccount.com
       #     workload_identity_provider: projects/000000000000/locations/global/workloadIdentityPools/devops/providers/github

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2.0.0
+        uses: docker/setup-buildx-action@v2.2.1
 
       - name: Build Test Image
         id: build-test-image

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build Test Image
         id: build-test-image
-        uses: docker/build-push-action@v3.1.1
+        uses: docker/build-push-action@v3.2.0
         with:
           load: true
           target: testing
@@ -110,7 +110,7 @@ jobs:
 
       # - name: Build & Push Release Image
       #   id: build-and-push-release-image
-      #   uses: docker/build-push-action@v3.1.1
+      #   uses: docker/build-push-action@v3.2.0
       #   with:
       #     push: true
       #     target: release

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -103,7 +103,7 @@ jobs:
       #     workload_identity_provider: projects/000000000000/locations/global/workloadIdentityPools/devops/providers/github
 
       # - name: Set up Google Cloud SDK
-      #   uses: google-github-actions/setup-gcloud@v0.6.0
+      #   uses: google-github-actions/setup-gcloud@v1.0.0
 
       # - name: Authorize push to Google Cloud Artifact Registry
       #   run: gcloud auth configure-docker us-central1-docker.pkg.dev


### PR DESCRIPTION
Updates the project's GitHub Actions workflows to fix deprecation notices arising from https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/