### PR TITLE
Fix class documentation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-#= Application Controller
-#
-# Base controller for all other controllers.
+# Base controller used to handle web requests
 class ApplicationController < ActionController::Base
   helper_method :current_user, :user_signed_in?
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-#= HomeController
-#
-# Handles the home or start page actions.
+# Handles the home web requests
 class HomeController < ApplicationController
   def show; end
 end

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-#= SessionController
-#
-# Handles the user session actions.
+# Handles the user session web requests
 class SessionController < ApplicationController
   def new; end
 

--- a/app/models/identity_platform/cert_store.rb
+++ b/app/models/identity_platform/cert_store.rb
@@ -3,11 +3,8 @@
 require 'net/http'
 
 module IdentityPlatform
-  #= IdentityPlatform::CertStore
-  #
-  # This class is used by the DecodeIdentityToken service to retrieve and store
-  # the certificates used to properly decode tokens issued by Google Cloud
-  # Identity Platform
+  # Retrieves and stores the certificates used to properly decode tokens issued
+  # by Google Cloud Identity Platform
   class CertStore
     extend MonitorMixin
 

--- a/app/models/identity_platform/error.rb
+++ b/app/models/identity_platform/error.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module IdentityPlatform
-  #= IdentityPlatform::Error
+  # An error returned by the Google Cloud Identity Platform
   class Error < StandardError; end
 end

--- a/app/models/identity_platform/token.rb
+++ b/app/models/identity_platform/token.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 module IdentityPlatform
-  #= IdentityPlatform::Token
-  #
-  # The tokens we obtain when authenticating users through Google Cloud Identity
+  # The token we obtain when authenticating users through Google Cloud Identity
   # Platform
   class Token
     include ActiveModel::Model

--- a/app/models/identity_platform/warden_strategy.rb
+++ b/app/models/identity_platform/warden_strategy.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 module IdentityPlatform
-  #= IdentityPlatform::WardenStrategy
-  #
-  # A warden strategy to authenticate users with a token from Identity Platform
+  # A warden strategy to authenticate users with a token from Google Cloud
+  # Identity Platform
   class WardenStrategy < Warden::Strategies::Base
     def valid?
       !token_string.nil?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-#= User
-#
 # A person who has an account on the site (via Google Cloud Identity Platform).
 class User < ApplicationRecord
   validates :identity_platform_id, presence: true, uniqueness: true

--- a/spec/system/support/cuprite.rb
+++ b/spec/system/support/cuprite.rb
@@ -60,8 +60,6 @@ end
 # Configure Capybara to use :cuprite driver by default
 Capybara.default_driver = Capybara.javascript_driver = :cuprite_remote
 
-#= CupriteHelpers
-#
 # A couple of methods used to help the development of system tests
 module CupriteHelpers
   # Drop #pause anywhere in a test to stop the execution.


### PR DESCRIPTION
Makes corrections to class documentation comments so that redundant class name is removed from the IDE popups:

Before:
<img width="355" alt="Screenshot 2022-11-09 at 17 45 44" src="https://user-images.githubusercontent.com/1915931/200970992-a63eba5b-0554-418f-ba70-515aabd6fda4.png">

After:
<img width="313" alt="Screenshot 2022-11-09 at 17 45 56" src="https://user-images.githubusercontent.com/1915931/200971011-a0c75cf6-57f9-40ef-9c75-a31475ae15d4.png">
